### PR TITLE
Escape " in method names

### DIFF
--- a/lib/ruby-prof-speedscope.rb
+++ b/lib/ruby-prof-speedscope.rb
@@ -17,7 +17,7 @@ module RubyProf
       @result.threads.each do |thread|
         thread.methods.each_with_index do |method, idx|
           next if frames.has_key?(method.object_id)
-          name = "#{method.klass_name}##{method.method_name}"
+          name = "#{method.klass_name}##{method.method_name.to_s.gsub('"', '\"')}"
           name += " *recursive*" if method.recursive?
           @output << <<~FRAME
             {


### PR DESCRIPTION
Fix for cases when some method names could contain ", for example "Mustermann::Grape::Parser#read \"*\"", which breaks JSON format. 

Before
```
...
"name": "Mustermann::Grape::Parser#read "*""
...
```
After 

```
...
"name": "Mustermann::Grape::Parser#read \"*\""
...
```